### PR TITLE
Release/1.0.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release gem to RubyGems.org
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    environment: release
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@ CHANGELOG
 ---------
 
 - **Unreleased**
+
+
+- **April.7.26**: 1.0.10
   - Add Github CI with modern Ruby versions
+  - Use Rubygem's trusted publishing
+  - Compability fixes
 
 - **July.27.12**: 1.0.6
   - conditionaly register XLSX mime type

--- a/Rakefile
+++ b/Rakefile
@@ -1,24 +1,19 @@
 require File.expand_path(File.dirname(__FILE__) + '/lib/acts_as_xlsx/version.rb')
 
-task :build => :gendoc do
-  system "gem build acts_as_xlsx.gemspec"
-end
+require 'bundler'
+Bundler::GemHelper.install_tasks
 
-task :gendoc do   
+task :gendoc do
   system "yardoc"
 end
 
-task :test do 
+task :test do
      require 'rake/testtask'
      Rake::TestTask.new do |t|
        t.libs << 'test'
        t.test_files = FileList['test/**/tc_*.rb']
        t.verbose = true
      end
-end
-
-task :release => :build do
-  system "gem push acts_as_xlsx-#{Axlsx::Ar::VERSION}.gem"
 end
 
 task :default => :test

--- a/lib/acts_as_xlsx/version.rb
+++ b/lib/acts_as_xlsx/version.rb
@@ -1,6 +1,6 @@
 module Axlsx
   module Ar
     # The current version of the gem
-    VERSION = "1.0.9"
+    VERSION = "1.0.10"
   end
 end


### PR DESCRIPTION
I'm drafting this release to introduce Github CI and trusted publishing to Rubygems. The latest version on Rubygems is `v1.0.8`, the codebase has `v1.0.9`, so I'm aiming for the next patch version, `v1.0.10`.

Thanks again @tillsc for all the fixes and maintenance you put into the project, I already turned on all notifications to not let you down again.

Let me know if I missed something, if all looks good, then I'll merge and deploy it in the next few days